### PR TITLE
Removed code that stripped [ATTACH] tags

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -502,7 +502,7 @@ class VBulletin extends ExportController {
         $discussion_Map = array(
             'title' => array('Column' => 'Name', 'Filter' => 'HTMLDecoder'),
             'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
-                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                    return $value;
                 }
             ),
         );
@@ -547,7 +547,7 @@ class VBulletin extends ExportController {
         // Comments
         $comment_Map = array(
             'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
-                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                    return $value;
                 }
             ),
         );


### PR DESCRIPTION
Porter is stripping out all the attachment BBCcode from Discussions and Posts so when you transfer no attachments exists in posts anymore.

I have tested this using my vB forums and porting to Vanilla 3.3 and BBCode is replaced by link to attachment as long as you copied over your attachments directory form export you are good!